### PR TITLE
Expose GAHQResponse Exception when request fails

### DIFF
--- a/src/HqSdk.php
+++ b/src/HqSdk.php
@@ -158,7 +158,11 @@ abstract class HqSdk {
     $file = $this->toObject(TypeConverter::xmlToArray($file, TypeConverter::XML_MERGE));
     
     if($file->GAHQResponses->TotalExceptions > 0){
-      throw new \Exception('There was an error submitting your request. Please check your data before trying again.');
+      throw new \Exception(
+          'There was an error submitting your request. Please check your data before trying again.',
+          0,
+          new \Exception($file->GAHQResponses->GAHQResponse->value)
+      );
     }
 
     return $file;

--- a/src/HqSdk.php
+++ b/src/HqSdk.php
@@ -156,8 +156,8 @@ abstract class HqSdk {
     // 
     $file = utf8_encode ( (string) $result );
     $file = $this->toObject(TypeConverter::xmlToArray($file, TypeConverter::XML_MERGE));
-    
-    if($file->GAHQResponses->TotalExceptions > 0){
+
+    if($file->GAHQResponses->GAHQResponse && $file->GAHQResponses->GAHQResponse->Type === 'Exception') {
       throw new \Exception(
           'There was an error submitting your request. Please check your data before trying again.',
           0,


### PR DESCRIPTION
This will add the exception included in the response from the GoAbroadHQ API in the exception stack to take the pain out of debugging API calls.
